### PR TITLE
Uniqueify keys

### DIFF
--- a/lib/dry/equalizer.rb
+++ b/lib/dry/equalizer.rb
@@ -19,7 +19,7 @@ module Dry
     #
     # @api private
     def initialize(*keys)
-      @keys = keys
+      @keys = keys.uniq
       define_methods
       freeze
     end

--- a/spec/unit/equalizer/universal_spec.rb
+++ b/spec/unit/equalizer/universal_spec.rb
@@ -152,4 +152,42 @@ RSpec.describe Dry::Equalizer do
       end
     end
   end
+
+  context 'with duplicate keys' do
+    subject { Dry::Equalizer(*keys) }
+
+    let(:keys)       { %i[firstname firstname lastname].freeze  }
+    let(:firstname)  { 'John'                                   }
+    let(:lastname)   { 'Doe'                                    }
+    let(:instance)   { klass.new(firstname, lastname)           }
+
+    let(:klass) do
+      ::Class.new do
+        attr_reader :firstname, :lastname
+        private :firstname, :lastname
+
+        def initialize(firstname, lastname)
+          @firstname = firstname
+          @lastname = lastname
+        end
+      end
+    end
+
+    before do
+      # specify the class #inspect method
+      allow(klass).to receive_messages(name: nil, inspect: name)
+      klass.send(:include, subject)
+    end
+
+    it { should be_instance_of(described_class) }
+
+    it { should be_frozen }
+
+    describe '#inspect' do
+      it 'returns the expected string' do
+        expect(instance.inspect)
+          .to eql('#<User firstname="John" lastname="Doe">')
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have [an app](https://github.com/radar/exploding-rails-rom-dry-example-app/tree/5bd5e043a67f42d6a74f084564af06beca70c9b0) that uses rom-rb, along with some dry libraries. When I make this call in my console, this happens:

```
irb(main):001:0> project_repo = ProjectRepository.new(ROM.env)
=> #<ProjectRepository struct_namespace=Projects auto_struct=true>
irb(main):002:0> project_repo.by_id_with_tickets(1)
=> #<Projects::Project id=1 name="Test Project" id=1 id=1 name="Test Project" tickets=[#<Projects::Ticket id=1 title="Test" comment="Test" project_id=1 user_id=1>]>
```

The `id` and `name` keys are duplicated here, for reasons I'm not quite clear on.

I think a good way to work around this would be to de-dup the keys at the `Dry::Equalizer` level, so that any library that used `Dry::Equalizer` could have this bug fixed. Another solution might be to fix it at the ROM level, but I don't know where in ROM that this is happening.