### PR TITLE
Uniqueify keys, take two

### DIFF
--- a/lib/dry/equalizer.rb
+++ b/lib/dry/equalizer.rb
@@ -19,7 +19,7 @@ module Dry
     #
     # @api private
     def initialize(*keys)
-      @keys = keys.uniq
+      @keys = keys
       define_methods
       freeze
     end
@@ -45,9 +45,10 @@ module Dry
     #
     # @api private
     def define_methods
-      define_cmp_method
-      define_hash_method
-      define_inspect_method
+      keys = @keys.uniq
+      define_cmp_method(keys)
+      define_hash_method(keys)
+      define_inspect_method(keys)
     end
 
     # Define an #cmp? method based on the instance's values identified by #keys
@@ -55,8 +56,7 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def define_cmp_method
-      keys = @keys
+    def define_cmp_method(keys)
       define_method(:cmp?) do |comparator, other|
         keys.all? do |key|
           __send__(key).public_send(comparator, other.__send__(key))
@@ -70,8 +70,7 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def define_hash_method
-      keys = @keys
+    def define_hash_method(keys)
       define_method(:hash) do | |
         keys.map(&method(:send)).push(self.class).hash
       end
@@ -82,8 +81,7 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def define_inspect_method
-      keys = @keys
+    def define_inspect_method(keys)
       define_method(:inspect) do | |
         klass = self.class
         name  = klass.name || klass.inspect


### PR DESCRIPTION
This is a follow-up to #8. I came back to my project today and discovered that dry-equalizer 0.2.1 does not fix this issue for my project, but seemingly fixes at least _one_ case because the tests pass.

So here's a different approach which makes all the tests pass _and_ fixes the issue in my project.

I have absolutely no idea whatsoever why this code is functionally different to what I had before, but there you go. Possibly a Ruby idiosyncrasy?