### PR TITLE
Travis: Update matrix; drop script directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: ruby
 cache: bundler
 bundler_args: --without benchmarks tools
-script:
-  - bundle exec rake
-before_install:
-  - gem update --system
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
-  - jruby-9.1.15.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
+  - jruby-9.2.5.0
 env:
   global:
     - COVERAGE=true

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'bundler'
   gem 'rake'
   gem 'rspec', '~> 3.5'
 end

--- a/dry-equalizer.gemspec
+++ b/dry-equalizer.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE README.md CONTRIBUTING.md]
 
   gem.required_ruby_version = '>= 2.0.0'
-
-  gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end


### PR DESCRIPTION
This PR keeps the Travis configuration up-to-date.

## Travis configuration

  - the `script` directive was the Travis default, so it was removed from configuration
  - the `gem update --system` directive was removed for compatibility reasons
  - to avoid trouble in Bundler's own selection of `bundler` gem, the development dependencies were moved from the gemspec into the `Gemfile`

## Matrix updates

  - add 2.6.1
  - add JRuby latest release
  - update patch versions of Rubies
