### PR TITLE
CI: use jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
 env:
   global:
     - COVERAGE=true


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)