### PR TITLE
Make generation of #inspect and #to_s optional

### DIFF
--- a/lib/dry/equalizer.rb
+++ b/lib/dry/equalizer.rb
@@ -2,8 +2,8 @@ module Dry
   # Build an equalizer module for the inclusion in other class
   #
   # @api public
-  def self.Equalizer(*keys)
-    Dry::Equalizer.new(*keys)
+  def self.Equalizer(*keys, **options)
+    Dry::Equalizer.new(*keys, **options)
   end
 
   # Define equality, equivalence and inspection methods
@@ -18,9 +18,9 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def initialize(*keys)
+    def initialize(*keys, inspect: true)
       @keys = keys.uniq
-      define_methods
+      define_methods(inspect: inspect)
       freeze
     end
 
@@ -44,10 +44,10 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def define_methods
+    def define_methods(inspect: true)
       define_cmp_method
       define_hash_method
-      define_inspect_method
+      define_inspect_method if inspect
     end
 
     # Define an #cmp? method based on the instance's values identified by #keys

--- a/spec/unit/equalizer/universal_spec.rb
+++ b/spec/unit/equalizer/universal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dry::Equalizer do
     before do
       # specify the class #name method
       allow(klass).to receive(:name).and_return(name)
-      klass.send(:include, subject)
+      klass.include(subject)
     end
 
     let(:instance) { klass.new }
@@ -92,7 +92,7 @@ RSpec.describe Dry::Equalizer do
     before do
       # specify the class #inspect method
       allow(klass).to receive_messages(name: nil, inspect: name)
-      klass.send(:include, subject)
+      klass.include(subject)
     end
 
     it { should be_instance_of(described_class) }
@@ -176,7 +176,7 @@ RSpec.describe Dry::Equalizer do
     before do
       # specify the class #inspect method
       allow(klass).to receive_messages(name: nil, inspect: name)
-      klass.send(:include, subject)
+      klass.include(subject)
     end
 
     it { should be_instance_of(described_class) }
@@ -187,6 +187,30 @@ RSpec.describe Dry::Equalizer do
       it 'returns the expected string' do
         expect(instance.inspect)
           .to eql('#<User firstname="John" lastname="Doe">')
+      end
+    end
+  end
+
+  context 'with options' do
+    context 'w/o inspect' do
+      subject { Dry::Equalizer(*keys, inspect: false) }
+
+      let(:keys)       { %i[firstname lastname].freeze  }
+      let(:firstname)  { 'John'                         }
+      let(:lastname)   { 'Doe'                          }
+      let(:instance)   { klass.new(firstname, lastname) }
+
+      let(:klass) do
+        ::Struct.new(:firstname, :lastname)
+      end
+
+      before { klass.include(subject) }
+
+      describe '#inspect' do
+        it 'returns the default string' do
+          expect(instance.inspect).to eql('#<struct firstname="John", lastname="Doe">')
+          expect(instance.to_s).to eql('#<struct firstname="John", lastname="Doe">')
+        end
       end
     end
   end


### PR DESCRIPTION
This adds a new option to `Dry.Equalizer` for skipping introspection methods:
```ruby
include Dry::Equalizer(:name, :age, inspect: false)
```