### PR TITLE
Immutable option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,23 @@ language: ruby
 cache: bundler
 bundler_args: --without benchmarks tools
 after_success:
-  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
+  - "[ -d coverage ] && bundle exec codeclimate-test-reporter"
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - jruby-9.2.7.0
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9
   - truffleruby
+  - ruby-head
 matrix:
+  include:
+    - rvm: jruby-9.2.8.0
+      jdk: openjdk8
   allow_failures:
     - rvm: truffleruby
-env:
-  global:
-    - COVERAGE=true
-    - JRUBY_OPTS='--dev -J-Xmx1024M'
+    - rvm: ruby-head
 notifications:
   email: false
   webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/19098b4253a72c9796db
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_success: change # options: [always|never|change] default: always
+    on_failure: always # options: [always|never|change] default: always
+    on_start: false # default: false

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported Ruby Versions
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* MRI 2.2+
+* MRI 2.4+
 * JRuby 9.x
 
 If something doesn't work on one of these versions, it's a bug.

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -12,6 +12,8 @@ name: dry-equalizer
 ### Usage
 
 ```ruby
+require 'dry-equalizer'
+
 class GeoLocation
   include Dry::Equalizer(:latitude, :longitude)
 
@@ -38,3 +40,47 @@ point_a.hash == point_c.hash # => false
 point_a.eql?(point_c)        # => false
 point_a.equal?(point_c)      # => false
 ```
+
+### Configuration options
+
+#### inspect
+
+Use `inspect` option to skip `#inspect` method overloading:
+
+```ruby
+class Foo
+  include Dry::Equalizer(:a, inspect: false)
+
+  attr_reader :a, :b
+
+  def initialize(a, b)
+    @a, @b = a, b
+  end
+end
+
+Foo.new(1, 2).inspect
+# => "#<Foo:0x00007fbc9c0487f0 @a=1, @b=2>"
+```
+
+#### immutable
+
+For objects that are immutable it doesn't make sense to calculate `#hash` every time it's called. To memoize hash use `immutable` option:
+
+```ruby
+class ImmutableHash
+  include Dry::Equalizer(:foo, :bar, immutable: true)
+
+  attr_accessor :foo, :bar
+
+  def initialize(foo, bar)
+    @foo, @bar = foo, bar
+  end
+end
+
+obj = ImmutableHash.new('foo', 'bar')
+obj.hash
+
+obj.foo = 'changed'
+obj.hash
+```
+

--- a/dry-equalizer.gemspec
+++ b/dry-equalizer.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.email       = %w[dan.kubb@gmail.com mbj@schirp-dso.com]
   gem.description = 'Module to define equality, equivalence and inspection methods'
   gem.summary     = gem.description
-  gem.homepage    = 'https://github.com/dryrb/dry-equalizer'
+  gem.homepage    = 'https://github.com/dry-rb/dry-equalizer'
   gem.licenses    = 'MIT'
 
   gem.require_paths    = %w[lib]
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.test_files       = `git ls-files -- spec/{unit,integration}`.split("\n")
   gem.extra_rdoc_files = %w[LICENSE README.md CONTRIBUTING.md]
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.4.0'
 end

--- a/lib/dry/equalizer.rb
+++ b/lib/dry/equalizer.rb
@@ -77,11 +77,14 @@ module Dry
     #
     # @api private
     def define_hash_method(immutable:)
-      keys = @keys
-      calculate_hash = ->(obj) { keys.map { |key| obj.send(key) }.push(obj.class).hash }
+      calculate_hash = ->(obj) { @keys.map { |key| obj.send(key) }.push(obj.class).hash }
       if immutable
         define_method(:hash) do
           @__hash__ ||= calculate_hash.call(self)
+        end
+        define_method(:freeze) do
+          hash
+          super()
         end
       else
         define_method(:hash) do

--- a/lib/dry/equalizer.rb
+++ b/lib/dry/equalizer.rb
@@ -14,13 +14,16 @@ module Dry
     # #hash, and #inspect
     #
     # @param [Array<Symbol>] keys
+    # @param [Hash] options
+    # @option options [Boolean] :inspect whether to define #inspect method
+    # @option options [Boolean] :immutable whether to memoize #hash method
     #
     # @return [undefined]
     #
     # @api private
-    def initialize(*keys, inspect: true)
+    def initialize(*keys, **options)
       @keys = keys.uniq
-      define_methods(inspect: inspect)
+      define_methods(**options)
       freeze
     end
 
@@ -36,17 +39,20 @@ module Dry
     # @api private
     def included(descendant)
       super
-      descendant.send(:include, Methods)
+      descendant.include Methods
     end
 
     # Define the equalizer methods based on #keys
     #
+    # @param [Boolean] inspect whether to define #inspect method
+    # @param [Boolean] immutable whether to memoize #hash method
+    #
     # @return [undefined]
     #
     # @api private
-    def define_methods(inspect: true)
+    def define_methods(inspect: true, immutable: false)
       define_cmp_method
-      define_hash_method
+      define_hash_method(immutable: immutable)
       define_inspect_method if inspect
     end
 
@@ -70,10 +76,17 @@ module Dry
     # @return [undefined]
     #
     # @api private
-    def define_hash_method
+    def define_hash_method(immutable:)
       keys = @keys
-      define_method(:hash) do | |
-        keys.map(&method(:send)).push(self.class).hash
+      calculate_hash = ->(obj) { keys.map { |key| obj.send(key) }.push(obj.class).hash }
+      if immutable
+        define_method(:hash) do
+          @__hash__ ||= calculate_hash.call(self)
+        end
+      else
+        define_method(:hash) do
+          calculate_hash.call(self)
+        end
       end
     end
 
@@ -84,7 +97,7 @@ module Dry
     # @api private
     def define_inspect_method
       keys = @keys
-      define_method(:inspect) do | |
+      define_method(:inspect) do
         klass = self.class
         name  = klass.name || klass.inspect
         "#<#{name}#{keys.map { |key| " #{key}=#{__send__(key).inspect}" }.join}>"
@@ -122,6 +135,6 @@ module Dry
       def ==(other)
         other.is_a?(self.class) && cmp?(__method__, other)
       end
-    end # module Methods
-  end # class Equalizer
+    end
+  end
 end

--- a/spec/unit/equalizer/universal_spec.rb
+++ b/spec/unit/equalizer/universal_spec.rb
@@ -161,6 +161,15 @@ RSpec.describe Dry::Equalizer do
         it 'returns memoized hash' do
           expect { instance.firstname = 'Changed' }.not_to(change { instance.hash })
         end
+        
+        context 'when frozen' do
+          it 'returns memoized hash' do
+            instance.freeze
+
+            expect(instance.hash)
+              .to eql([firstname, lastname, klass].hash)
+          end
+        end
       end
     end
   end

--- a/spec/unit/equalizer/universal_spec.rb
+++ b/spec/unit/equalizer/universal_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Dry::Equalizer do
     let(:klass) do
       ::Class.new do
         attr_reader :firstname, :lastname
+        attr_writer :firstname
         private :firstname, :lastname
 
         def initialize(firstname, lastname)
@@ -149,6 +150,17 @@ RSpec.describe Dry::Equalizer do
       it 'returns the expected string' do
         expect(instance.inspect)
           .to eql('#<User firstname="John" lastname="Doe">')
+      end
+    end
+
+    context 'when immutable' do
+      describe '#hash' do
+
+        subject { Dry::Equalizer(*keys, immutable: true) }
+
+        it 'returns memoized hash' do
+          expect { instance.firstname = 'Changed' }.not_to(change { instance.hash })
+        end
       end
     end
   end


### PR DESCRIPTION
Uses `Dry::Core::Memoizable` to memoize hash result.

WARN: Drops support for Ruby < 2.4

Closes #3 