### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/dry-equalizer.gemspec
+++ b/dry-equalizer.gemspec
@@ -10,6 +10,13 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'https://github.com/dry-rb/dry-equalizer'
   gem.licenses    = 'MIT'
 
+  gem.metadata = {
+    'bug_tracker_uri' => 'https://github.com/dry-rb/dry-equalizer/issues',
+    'changelog_uri' => "https://github.com/dry-rb/dry-equalizer/blob/v#{gem.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/dry-equalizer/#{gem.version}",
+    'source_code_uri' => "https://github.com/envato/dry-rb/dry-equalizer/v#{gem.version}"
+  }
+
   gem.require_paths    = %w[lib]
   gem.files            = `git ls-files`.split("\n")
   gem.test_files       = `git ls-files -- spec/{unit,integration}`.split("\n")


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/dry-equalizer), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.